### PR TITLE
Design consistency pass: real CSS/component bugs + blog post grammar and code fixes

### DIFF
--- a/public/style/classes/blog-content.css
+++ b/public/style/classes/blog-content.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 32px;
+  max-width: 100%;
 }
 
 .blog-content :is(h1, h2, h3, h4, h5, h6) {
@@ -55,10 +56,6 @@
 
 .blog-content p {
   line-height: 1.5;
-}
-
-.blog-content {
-  max-width: 100%;
 }
 
 @media screen and (orientation: landscape) {

--- a/public/style/classes/gdpr-request.css
+++ b/public/style/classes/gdpr-request.css
@@ -1,0 +1,15 @@
+.gdpr-request {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  padding: 16px;
+  background-color: var(--color-midground);
+  box-shadow: var(--box-shadow);
+}
+.gdpr-request > :first-child {
+  margin-right: auto;
+}

--- a/public/style/classes/index.css
+++ b/public/style/classes/index.css
@@ -5,3 +5,4 @@
 @import "./color-theme-toggler.css";
 @import "./mouse-chaser-toggler.css";
 @import "./blog-content.css";
+@import "./gdpr-request.css";

--- a/public/style/tags/a.css
+++ b/public/style/tags/a.css
@@ -32,11 +32,11 @@ a.link-inverted {
   color: var(--color-link-alt);
 }
 a.link-inverted:visited {
-  color: var(--color-link-alt-visited);
+  color: var(--color-link-alt--visited);
 }
 a.link-inverted:active,
 a.link-inverted:hover {
-  color: var(--color-link-alt-interaction);
+  color: var(--color-link-alt--interaction);
 }
 
 a.link-inverted.link-untracked,
@@ -51,7 +51,7 @@ a.link-inverted.link-untracked:active,
 a.link-inverted.link-untracked:hover,
 .link-inverted.link-untracked > *:active,
 .link-inverted.link-untracked > *:hover {
-  color: var(--color-link-alt-interaction);
+  color: var(--color-link-alt--interaction);
 }
 
 a.link-surprise {

--- a/public/style/tags/body.css
+++ b/public/style/tags/body.css
@@ -52,7 +52,7 @@ body > :is(header, footer) a:visited {
 
 body > :is(header, footer) a:hover,
 body > :is(header, footer) a:active {
-  color: var(--color-text-highlight);
+  color: var(--color-text--highlight);
 }
 
 body > :is(header, footer) > a > img {

--- a/public/style/tags/section.css
+++ b/public/style/tags/section.css
@@ -213,6 +213,7 @@ section.blog-preview header {
 
 section.blog-preview img {
   border-radius: 8px;
+  width: 192px;
 }
 
 section.blog-preview article {
@@ -234,10 +235,6 @@ section.blog-preview article header {
     padding-right: var(--padding-side);
     flex-direction: row;
   }
-}
-
-section.blog-preview img {
-  width: 192px;
 }
 
 section.blog > article {

--- a/src/components/BlogPage.astro
+++ b/src/components/BlogPage.astro
@@ -6,8 +6,6 @@ SITE_CANONICAL_URL} from "../SETTINGS.mjs";
 // Utilites
 // Components
 import SitePage from "./SitePage.astro";
-// Content
-import headerLinks from "../content/headerlinks.mjs";
 const { frontmatter } = Astro.props;
 const {
     description,
@@ -24,7 +22,6 @@ const {
   keywords={SITE_KEYWORDS.concat(tags)}
   author={author}
   canonical={new URL(frontmatter.url, SITE_CANONICAL_URL).href}
-  headerLinks={headerLinks}
   meta={{og:{image:heroImage}}}
   >
   <section class="blog-top">

--- a/src/components/GDPRRequest.astro
+++ b/src/components/GDPRRequest.astro
@@ -96,8 +96,8 @@ const { message, accept, decline } = Astro.props;
     globalThis.location.reload();
   }
 </script>
-<footer class="fixed bottom-0 flex p-4 justify-end items-center" style="display: var(--gdpr-consent, none);">
-  <div class="mr-auto">{message ?? DEFAULT_MESSAGE}</div>
+<footer class="gdpr-request" style="display: var(--gdpr-consent, none);">
+  <div>{message ?? DEFAULT_MESSAGE}</div>
   <a href="#" onclick="globalThis.dispatchEvent(new Event('gdpr-consent-provided'));">{accept ?? DEFAULT_ACCEPT}</a>
   <a href="#" onclick="globalThis.dispatchEvent(new Event('gdpr-consent-withheld'));">{decline ?? DEFAULT_DECLINE}</a>
 </footer>

--- a/src/components/SiteBody.astro
+++ b/src/components/SiteBody.astro
@@ -2,8 +2,8 @@
 // Settings
 // Components
 import {SITE_CDN_URL} from "../SETTINGS.mjs";
-import GDPRRequest from './GDPRRequest.astro';
-import TagManagerBody from './plain/TagManagerBody.astro';
+import GDPRRequest from "./GDPRRequest.astro";
+import TagManagerBody from "./plain/TagManagerBody.astro";
 import headerLinks from "../content/headerlinks.mjs";
 // Content
 const { title, headerClass, footerClass, author, tmid} = Astro.props;

--- a/src/components/SitePage.astro
+++ b/src/components/SitePage.astro
@@ -2,13 +2,12 @@
 // Settings
 // Components
 import {SITE_TITLE, TAG_MANAGER_ID, SITE_FAVICON, SITE_FAVICON_TYPE, SITE_CANONICAL_URL, SITE_DESCRIPTION, SITE_KEYWORDS, SITE_AUTHOR} from "../SETTINGS.mjs";
-import headerLinks from "../content/headerlinks.mjs";
 // Content
-import externalStyles from '../external/styles.mjs';
-import externalScripts from '../external/scripts.mjs';
-import webComponents from '../external/components.mjs';
-import appleTouchIcons from '../external/apple-touch-icons.mjs';
-import defaultMeta from '../external/meta.mjs';
+import externalStyles from "../external/styles.mjs";
+import externalScripts from "../external/scripts.mjs";
+import webComponents from "../external/components.mjs";
+import appleTouchIcons from "../external/apple-touch-icons.mjs";
+import defaultMeta from "../external/meta.mjs";
 import GenericPage from "./plain/GenericPage.astro";
 import SiteBody from "./SiteBody.astro";
 const {
@@ -29,8 +28,7 @@ author,
 externalStyles,
 externalScripts,
 webComponents,
-appleTouchIcons,
-headerLinks
+appleTouchIcons
 }
 const titles = [SITE_TITLE];
 if(subtitle){

--- a/src/components/plain/Head.astro
+++ b/src/components/plain/Head.astro
@@ -6,13 +6,13 @@
 // - no <meta http-equiv="content-language"> (not emitted by 0.0.6)
 // Settings
 // Components
-import AppleTouchIconLinks from './head/AppleTouchIconLinks.astro';
-import DefineWebComponents from './head/DefineWebComponents.astro';
-import MiscellaneousMeta from './head/MiscellaneousMeta.astro';
+import AppleTouchIconLinks from "./head/AppleTouchIconLinks.astro";
+import DefineWebComponents from "./head/DefineWebComponents.astro";
+import MiscellaneousMeta from "./head/MiscellaneousMeta.astro";
 import ServiceWorkerScript from "./head/ServiceWorkerScript.astro";
 import SiteScripts from "./head/SiteScripts.astro";
 import SiteStyles from "./head/SiteStyles.astro";
-import TagManagerHead from './head/TagManagerHead.astro';
+import TagManagerHead from "./head/TagManagerHead.astro";
 
 // Content
 const {

--- a/src/external/styles.mjs
+++ b/src/external/styles.mjs
@@ -2,7 +2,6 @@ import { SITE_LIB_URL, SITE_BASE_PATH, SITE_CDN_URL } from "../SETTINGS.mjs";
 
 export default [
   `${SITE_LIB_URL}vendor/css/reset/2.0.0/index.css`,
-  `${SITE_LIB_URL}vendor/css/reset/2.0.0/index.css`,
   `${SITE_LIB_URL}css/universal-unstyled-links/0.0.0/index.css`,
   `${SITE_LIB_URL}css/universal-box-sizing/0.0.0/index.css`,
   `${SITE_LIB_URL}css/universal-no-margins/0.0.0/index.css`,

--- a/src/pages/blog/posts/angular-done-right.md
+++ b/src/pages/blog/posts/angular-done-right.md
@@ -15,7 +15,7 @@ Author’s Note: While I no longer program heavily using angular, in favor of us
 
 Angular is hard, right?
 
-Well, one thing that’s for sure is that Angular is a massive. It’s a full application framework made of components including directives, controllers, services, and much much more. It’s shrouded in strange new concepts such as “_Dependency Injection_” and “_Transclausion_”. Despite it’s overall allure, anyone creating an angular app for the first time must accept that he or she is in for a steep learning curve due before being able to build anything fun or useful.
+Well, one thing that’s for sure is that Angular is a massive framework. It’s a full application framework made of components including directives, controllers, services, and much much more. It’s shrouded in strange new concepts such as “_Dependency Injection_” and “_Transclusion_”. Despite it’s overall allure, anyone creating an angular app for the first time must accept that he or she is in for a steep learning curve before being able to build anything fun or useful.
 
 That’s the approach that most tutorials on the web take. In this series we take different approach. We’ll gradually build upon the most basic concepts in angular; first introducing the bare minimum needed to build an application and building upon it as we go along.
 
@@ -30,7 +30,7 @@ We’ll start with a very basic HTML page. Create a basic html page with the fol
 </html>
 ```
 
-The next thing that you need to do is to download and include the angular.js file. You can download it directly from the [Angular JS homepage](https://angularjs.org/), or, if you perfer, using the [Bower package manager](http://bower.io/). I won’t go into specifics, on how exactly how to do that, but having made it this far, I doubt that you’ll have any trouble :).
+The next thing that you need to do is to download and include the angular.js file. You can download it directly from the [Angular JS homepage](https://angularjs.org/), or, if you prefer, using the [Bower package manager](http://bower.io/). I won’t go into specifics, on how exactly how to do that, but having made it this far, I doubt that you’ll have any trouble :).
 
 Once you’ve included the angular file in your app, your file should look something like this:
 
@@ -38,7 +38,7 @@ Once you’ve included the angular file in your app, your file should look somet
     <!doctype html>
     <html>
      <body>
-     <script src=”path/to/angular.js”></script>
+     <script src="path/to/angular.js"></script>
      </body>
     </html>
 ```
@@ -49,7 +49,7 @@ Once you’ve included the angular file in your app, your file should look somet
 
 There are two ways of bootstrapping an application. The easiest and most reliable way is to add the **ng-app \***directive\* to an html element. That element and all of it’s children will be part of your angular app.
 
-“_What are directives?_”, you must be wondering… Well, for now, just think of them as attibues that you can add to your html that let your app interact with angular. We’ll learn more about directives very soon, and in a later part of the series.
+“_What are directives?_”, you must be wondering… Well, for now, just think of them as attributes that you can add to your html that let your app interact with angular. We’ll learn more about directives very soon, and in a later part of the series.
 
 We could put it on any element — the **`<body>`** tag; a **`<div>`** tag — but lets go ahead and put it on the top level “html” element. This way, the entire page will be available to our application.
 
@@ -57,12 +57,12 @@ We could put it on any element — the **`<body>`** tag; a **`<div>`** tag — b
     <!doctype html>
     <html ng-app>
      <body>
-     <script src=”path/to/angular.js”></script>
+     <script src="path/to/angular.js"></script>
      </body>
     </html>
 ```
 
-There is another way to bootstrap your application (it actually uses the [angular.bootstrap](https://docs.angularjs.org/api/ng/function/angular.bootstrap) method!), but I have found it to be much more error-prone, so I wont at least into that method… at least not today.
+There is another way to bootstrap your application (it actually uses the [angular.bootstrap](https://docs.angularjs.org/api/ng/function/angular.bootstrap) method!), but I have found it to be much more error-prone, so I won't go into that method… at least not today.
 
 ### Binding
 
@@ -74,15 +74,15 @@ Now that you’ve set up the application, binding data is the simplest thing tha
     <!doctype html>
     <html ng-app>
      <body >
-     <input ng-model=”input”> <span ng-bind=”input”></span>
-     <script src=”path/to/angular.js”></script>
+     <input ng-model="input"> <span ng-bind="input"></span>
+     <script src="path/to/angular.js"></script>
      </body>
     </html>
 ```
 
 You’ve added two new directives. The** ng-model \***directives\* allows you to bind a variable to a standard html element that receives user input. This can be either an input element, a textarea element, or select element. (If you’re familiar with jQuery, this might remind you of the [val](http://api.jquery.com/val/) method.)
 
-The **ng-bind** directive does something similar, but but it works by replacing the inner html of any html element with the bound variable. (If you’re familiar with jQuery, this might remind you of the [html](http://api.jquery.com/html/) method.)
+The **ng-bind** directive does something similar, but it works by replacing the inner html of any html element with the bound variable. (If you’re familiar with jQuery, this might remind you of the [html](http://api.jquery.com/html/) method.)
 
 **input** is the name that we have chosen for the name of the variable to be bound, but we could have chosen pretty much anything.
 
@@ -90,7 +90,7 @@ Note: the variables exist within the scope of the application and not on the pag
 
 ```html
 <script>
-  var input = “Sorry, I’m not available for binding.”
+  var input = "Sorry, I'm not available for binding."
 </script>
 ```
 
@@ -100,8 +100,8 @@ You can also use the double curly braces syntax, `“[[input]]”`, instead of *
     <!doctype html>
     <html ng-app>
      <body >
-     <input ng-model=”input”><span>[[input]]</span>
-     <script src=”path/to/angular.js”></script>
+     <input ng-model="input"><span>[[input]]</span>
+     <script src="path/to/angular.js"></script>
      </body>
     </html>
 ```
@@ -112,38 +112,38 @@ This might be useful for, say, a form:
 
 ```html
 <form>
-  Name:<input ng-model="”user.name”" ng-required="”true”" />
+  Name:<input ng-model="user.name" ng-required="true" />
   <br />
   Favorite Color:
-  <select ng-model="”user.color”">
-    <option value="”not" available”>N/A</option>
-    <option value="”red”">Red</option>
-    <option value="”green”">Green</option>
-    <option value="”blue”">Blue</option>
+  <select ng-model="user.color">
+    <option value="not available">N/A</option>
+    <option value="red">Red</option>
+    <option value="green">Green</option>
+    <option value="blue">Blue</option>
   </select>
-  <div style="”background-color:[[user.color]]”"></div>
+  <div style="background-color:[[user.color]]"></div>
   <button>Submit</button>
 </form>
 <p>
   Your name is
-  <b ng-bind="”user.name" || ‘Blank’”></b>
+  <b ng-bind="user.name || 'Blank'"></b>
   and your favorite color is
-  <b ng-bind="”user.color”"></b>.
+  <b ng-bind="user.color"></b>.
 </p>
 ```
 
 Notice that the **user.name** and the **user.color** properties are bound to other parts of the form.
 
-You may have spotted the **ng-required** directive on the input tag. That’s prevents a form from being submitted unless the required value is filled out. Try submitting the form below without typing in a name. (Be Warned: This may not work in all browsers.)
+You may have spotted the **ng-required** directive on the input tag. That prevents a form from being submitted unless the required value is filled out. Try submitting the form below without typing in a name. (Be Warned: This may not work in all browsers.)
 
-It’s also useful to be able to perform calculations on the page. Here’s a simple tip calculator. It a bit off (check out those rounding errors!), but it starts to show you what you can do with an angular app.
+It’s also useful to be able to perform calculations on the page. Here’s a simple tip calculator. It's a bit off (check out those rounding errors!), but it starts to show you what you can do with an angular app.
 
 ```html
-    Bill: <input ng-model=”bill”>
+    Bill: <input ng-model="bill">
     <br/>
-    Tip Percentage: <input type=”number” ng-model=”tip”> %
+    Tip Percentage: <input type="number" ng-model="tip"> %
     <br/>
-    Total: $<span ng-bind=”(1 + (tip/100) ) * bill”></span>
+    Total: $<span ng-bind="(1 + (tip/100) ) * bill"></span>
 ```
 
 ### A Few More Directives
@@ -153,10 +153,10 @@ It’s also useful to be able to perform calculations on the page. Here’s a si
 Conveniently, attaching the **ng-model** to a checkbox or radio allows you to bind to its **checked** property rather than it’s value.
 
 ```html
-<input type="”checkbox”" ng-init="”checked" ="true”" ng-model="”checked”" />
-<span ng-show="”checked”">The box is checked</span>
-<span ng-hide="”checked”">The box is not checked</span>
-<span ng-if="”checked”"> :) </span>
+<input type="checkbox" ng-init="checked=true" ng-model="checked" />
+<span ng-show="checked">The box is checked</span>
+<span ng-hide="checked">The box is not checked</span>
+<span ng-if="checked"> :) </span>
 ```
 
 And we can use this fact to demonstrate a few new directives.
@@ -172,24 +172,10 @@ A final useful directive is the **ng-repeat** directive that allows one to itera
 
 ```html
 <ul
-  ng-init="”beatles"
-  ="["
-  [name
-  :
-  ‘John’],
-  [name
-  :
-  ‘Paul’],
-  [name
-  :
-  ‘George’],
-  [name
-  :
-  ‘Ringo’]
-  ]”
+  ng-init="beatles=[{name:'John'},{name:'Paul'},{name:'George'},{name:'Ringo'}]"
 >
-  <li ng-repeat="”beatle" in beatles”>
-    <span ng-bind="”$index”"></span>.<span ng-bind="”beatle.name”"></span>
+  <li ng-repeat="beatle in beatles">
+    <span ng-bind="$index"></span>.<span ng-bind="beatle.name"></span>
   </li>
 </ul>
 ```
@@ -201,8 +187,8 @@ You’ll notice that in addition to the **_beatle_** property, the **ng-repeat *
 Just for the heck of it, let’s take a sneak preview of filters.
 
 ```html
-<li ng-repeat="”beatle" in beatles | orderBy:’name’”>
-  <span ng-bind="”$index”"></span>.<span ng-bind="”beatle.name”"></span>
+<li ng-repeat="beatle in beatles | orderBy:'name'">
+  <span ng-bind="$index"></span>.<span ng-bind="beatle.name"></span>
 </li>
 ```
 
@@ -212,4 +198,4 @@ Filters, like Directives, are one of the core components of angular. And we’ll
 
 ### Conclusion
 
-With just few basic built built in components, you can start creating interesting apps with barely any code. I’ll be back soon with another update to this series, but in the meantime, start using Angular to make something cool!
+With just a few basic built-in components, you can start creating interesting apps with barely any code. I’ll be back soon with another update to this series, but in the meantime, start using Angular to make something cool!

--- a/src/pages/blog/posts/browsers-servers-and-apis.md
+++ b/src/pages/blog/posts/browsers-servers-and-apis.md
@@ -31,10 +31,10 @@ For instance, a server within a service worker would be able to intercept and re
     //example -- service worker
     const server = …;//define later
 
-    self.addEventListener(‘fetch’, function(event) {
+    self.addEventListener('fetch', function(event) {
      return event.respondWith(new Promise((resolve, reject)=>{
        const response = server.respondTo(event.request);
-       response.on(“finish”, ()=>{
+       response.on("finish", ()=>{
          resolve(req);
        });
      }));
@@ -45,7 +45,7 @@ We’ll come back to this idea...
 
 ## **Competing Standards**
 
-So, I want to put a server in the browser — what are my options? Not long ago, I learned about the new [FlyWeb](https://hacks.mozilla.org/2016/09/flyweb-pure-web-cross-device-interaction/) standard that [Mozilla](https://blog.mozilla.org/) is pushing for creating servers within the browser. I was pretty excited until i realized how different it was from anything that already existed in node.
+So, I want to put a server in the browser — what are my options? Not long ago, I learned about the new [FlyWeb](https://hacks.mozilla.org/2016/09/flyweb-pure-web-cross-device-interaction/) standard that [Mozilla](https://blog.mozilla.org/) is pushing for creating servers within the browser. I was pretty excited until I realized how different it was from anything that already existed in node.
 
 Every other server that I’ve seen follows a particular pattern…
 
@@ -56,7 +56,7 @@ Node already has a built in simple API for creating servers via [http](https://n
 ```javascript
     //example -- http
     //create server and define action
-    const server = require(“http”)
+    const server = require("http")
      .createServer((request, response)=>{
       ...//process request
       response.end();//end response
@@ -76,7 +76,7 @@ As the http module is quite simplistic, the [express](https://github.com/express
     //example -- express
 
     //create server
-    const server = require(“express”)();
+    const server = require("express")();
 
     //register middleware
     server.use((request, response, next)=>{
@@ -114,7 +114,7 @@ Koa makes use of [asynchronous functions](https://github.com/tc39/ecmascript-asy
 ```javascript
     //example -- koa
 
-    const server = require(“koa”)();
+    const server = require("koa")();
 
     server.use(async (context, next)=>{
       ...//process request
@@ -140,7 +140,7 @@ Please be aware that Koa 2 is still in alpha, but since its API is so much clean
 ```javascript
     //example -- rill
 
-    const server = require(“rill”)();
+    const server = require("rill")();
 
     server.use((context, next)=>{
       context.res.end();//end response
@@ -176,7 +176,7 @@ While rill or koa would have been a great starting point for a server in the bro
     };
 ```
 
-This breaks the pattern of everything we’ve seen so far! Here the server is created and started first. Only afterwards are actions actions added.
+This breaks the pattern of everything we’ve seen so far! Here the server is created and started first. Only afterwards are actions added.
 
 Do we really need an entirely new way of doing basically the same thing?
 
@@ -192,14 +192,14 @@ Revisiting the service worker example above, we have:
 
 ```javascript
     //example -- koa-2-browser
-    const server = require(‘koa-2-browser’)();
+    const server = require('koa-2-browser')();
     server.use(/*middleware*/);
     server.listen(()=>{
 
     self.onfetch(function(event) {
         return event.respondWith(new Promise((resolve, reject)=>{
           const response = server.respondTo(event.request,{browserResponse:true});
-          response.on(“finish”, (res)=>{
+          response.on("finish", (res)=>{
             resolve(res);
           });
         }));
@@ -227,21 +227,21 @@ And this is true for open source software as a whole; if two different APIs do t
 
 Servers aren’t the only competing standards across environments.
 
-[\*\*Buffers](https://nodejs.org/api/buffer.html)** are standardized in node and [**ArrayBuffers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)\*\* are standardized in the browser. They are both containers for binary data, but they work slightly differently. This is particularly annoying when attempting to create isomorphic applications. Even worse, some objects that have a “buffer” method, may return an ArrayBuffer instead, meaning that you may have to apply special logic to work with them in different environments.
+**[Buffers](https://nodejs.org/api/buffer.html)** are standardized in node and **[ArrayBuffers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)** are standardized in the browser. They are both containers for binary data, but they work slightly differently. This is particularly annoying when attempting to create isomorphic applications. Even worse, some objects that have a “buffer” method, may return an ArrayBuffer instead, meaning that you may have to apply special logic to work with them in different environments.
 
-After many revisions, [\*\*Streams](https://nodejs.org/api/stream.html)** are close to full standardization in node. Unfortunately, [**Browser Streams](https://streams.spec.whatwg.org/)\*\*, an emerging standard, introduce new and incompatible parts of the API. Hopefully, the groups involved can come to an agreement at some point.
+After many revisions, **[Streams](https://nodejs.org/api/stream.html)** are close to full standardization in node. Unfortunately, **[Browser Streams](https://streams.spec.whatwg.org/)**, an emerging standard, introduce new and incompatible parts of the API. Hopefully, the groups involved can come to an agreement at some point.
 
-There are some other similar topics like **importing modules**, but that situation is way more complicated to go into her.
+There are some other similar topics like **importing modules**, but that situation is way more complicated to go into here.
 
 ## Bonus Library!!!
 
 But trying new things is fun! I actually prefer the [way that FlyWeb creates servers](https://github.com/flyweb/spec). Since it [it appears that I’m not the only one](https://github.com/koajs/koa/issues/482), I’ve created another library, [flyweb-koa](https://github.com/johnhenry/flyweb-koa). It allows you to use koa in a manner similar to the FlyWeb, while maintaining everything that koa has to offer.
 
 ```javascript
-    const koa = require(“koa-2-browser”);
+    const koa = require("koa-2-browser");
     //This also works with koa;
 
-    const publishServer = require(‘flyweb-koa’)(‘koa’);
+    const publishServer = require('flyweb-koa')('koa');
 
     const server = await publishServer(/*listening address*/);
     server.use(/*middleware*/);

--- a/src/pages/blog/posts/component.md
+++ b/src/pages/blog/posts/component.md
@@ -1,134 +1,38 @@
-1. Build HTML APP
-2. Extend individual components with CSS
-3. Extend individual components with JS
-   1. Extend CSS with JS (CSS custom Property Sets)
-   2. Extend HTML with JS (Web Component Extensions)
-   3. Extend HTML with JS (Targeting DOM Elements)
+---
+title: "CSS Inheritance for JavaScript Programmers"
+description: "Classical inheritance, mixins, and prototypal inheritance in JavaScript, and what each one teaches us about how CSS inheritance and specificity actually work."
+date: "3 July 2026"
+author: "John Henry"
+heroImage: "/vendor/img/www.pexels.com/pixabay/view-of-street-from-a-glass-window.jpg"
+alt: "Astro"
+layout: "../../../components/BlogPage.astro"
+tags: ["programming", "experimenting"]
+---
 
-# Components
-
-What is a component?
-A component is a set of markup associated
-with a specific set of behaviors --
-incuding everyghing from mouse clicks to visusal representation.
-They are an essential part of declarative programming.
-
-A component's properties are not meant
-for said component's children.
-They may tell a component how to arrange
-a group of generic children within itself,
-but only on rare occasions should a component
-be aware of it's children's content.
-
-## HTML Elements
-
-HTML elements are the simplest components on the web.
-They consist of basic element tags.
-
-It's important to understand what already exists.
-
-## HTML Components
-
-Facts
-
-Pros:
-
-- encapsulation
--
-
-Cons:
-
-- importing is akward (can be fixed)
-- always creates outer element.
-  - can extend components to remove this
-    - safari does not support this
-      - ...without a polyfill
-
-https://minze.dev/api/#version-1
-
-## CSS
-
-CSS is used to add (and remove) visual (and interactive )
-behaviors to existing html components.
-
-CSS components are represented by selectors and properties are added to them.
-
-### CSS Modules
-
-### CSS Models
-
-Enhance existing CSS selectors by providing
-Javascipt-driven custom properties
-on the DOM.
-
-## Native DOM Components
-
-Facts:
-
-- Uses document api (document.addChild, etc.)
-
-Pros:
-
-Cons:
-
-- Cumbersom API
-  - Specifically adding children/attributes is
-    separate from construction.
-  - Specifically, can add children in bulk,
-    but modifying them in bulk
-
-### JSX
-
-Many frameworks use Javascript for XML (JSX).
-This is an XML-like language within avascript
-that can be used to transform a XML into nested functions
-that produce DOM elements
-
-```typescript
-(tagname:string, {children, }:{[string]:any, children:Element[]}):=> Element
-
-```
-
-### Attribute Based
-
-- HTMX
-
-# Component Inheritence
-
-This is Part 1 in a series.
-We learn what it takes to create a framework
-in which we build components using
-clean and uncomplied styles along with organized and meanigful markup.
-
-Inheritance is a useful concept.
-It allows programmers to streamline the way in which they
-design objects by reusing code.
-
-In this article, we take a look at how inheritance works
-through the eyes of a JavaScript programmer
-and understand how it applies when applying CSS.
+Inheritance is a useful concept. It lets programmers streamline the way they
+design objects by reusing code. In this article, we look at how inheritance
+works through the eyes of a JavaScript programmer, and use that lens to
+understand how CSS inheritance and specificity work.
 
 ## Normalize and Reset
 
-While they mostly work the same,
-different apply some browser-based styles
-to each page.
-For consistency,
-it is always a good idea to use a [normalize]()
-any time you work with CSS.
+Before any of this matters, it helps to start from the same baseline in
+every browser. Different browsers apply different default styles to the
+same elements, so it's always a good idea to use a
+[normalize](https://necolas.github.io/normalize.css/) stylesheet any time
+you work with CSS.
 
-We separate concerns -- meaning and style --
-by handing each with HTML and CSS respectively.
-We go beyond using a normalize and use a [reset]()
-to strip **all** styles associated with the HTML.
+We separate concerns — meaning and style — by handling each with HTML and
+CSS respectively. We go a step further than a normalize and use a
+[reset](https://meyerweb.com/eric/tools/css/reset/) to strip **all** styles
+associated with the HTML, so everything that follows is explicit and
+intentional.
 
-## Type: Classical Inheritence
+## Classical Inheritance
 
-A _class_ is a basic object that acts as a blueprint
-to crete other objects.
-
-In javascript we create a class with a number of
-property definitions[^1].
+A _class_ is a basic object that acts as a blueprint for creating other
+objects. In JavaScript, we create a class with a number of property
+definitions[^1]:
 
 ```javascript
 const House = class {
@@ -145,7 +49,7 @@ const House = class {
 };
 ```
 
-In a way, _selectors_ in CSS behave like classes.
+In a way, _selectors_ in CSS behave like classes:
 
 ```css
 section {
@@ -155,21 +59,18 @@ section {
 
 ### Instantiation and application
 
-Most languages use the "new" keyword to create
-an "instance" of the class.
-This is an object with the properties defined by the class.
+Most languages use the `new` keyword to create an "instance" of a class —
+an object with the properties defined by the class:
 
 ```javascript
-const house = new Class("red"); // "house" is like the actual house
+const house = new House("red"); // "house" is like the actual house
 console.log(house.getColor()); // logs "red"
 house.paint("blue");
 console.log(house.getColor()); // logs "blue"
 ```
 
-Rather than creating a new object,
-properties defined by a selector are
-automatically applied to HTML elements
-that they match.
+Rather than creating a new object, properties defined by a selector are
+automatically applied to every HTML element that matches it:
 
 ```html
 <section>This has a red background</section>
@@ -178,20 +79,19 @@ that they match.
 
 ### Extension
 
-Classes can be "extended".
+Classes can be "extended":
 
 ```javascript
-class BigRedHouse extends House class {
+class BigRedHouse extends House {
   constructor() {
     super("red");
-    this.isBig === true
+    this.isBig = true;
   }
 }
 ```
 
-Property definitons from the original class
-are included in the new class.
-We say the properties are "inherited".
+Property definitions from the original class are included in the new
+class. We say the properties are "inherited":
 
 ```javascript
 const bigRedHouse = new BigRedHouse();
@@ -199,19 +99,15 @@ console.log(bigRedHouse.getColor()); // logs "red"
 console.log(bigRedHouse.isBig); // logs "true"
 ```
 
-Some CSS preprocessors use a similar
-[concept of extension](https://sass-lang.com/documentation/at-rules/extend),
-This is not a feature of uncompiled CSS,
-so we will find another way.
+Some CSS preprocessors have a similar
+[concept of extension](https://sass-lang.com/documentation/at-rules/extend).
+That isn't a feature of plain, uncompiled CSS, so we find another way: we
+simulate it by defining and applying another type of selector, a CSS
+class. (To avoid ambiguity, I always refer to this kind of selector as a
+"CSS class".)
 
-We can simulate this by defining and applying
-another typer of selector, a CSS class.
-(To avoid ambiguity, I always refer to the selector
-as a "CSS class".)
-
-Placing two selectors together (with no space between)
-creates a new selector.
-Both selectors much match an element to be applied.
+Placing two selectors together, with no space between them, creates a new
+selector. Both selectors must match an element for it to apply:
 
 ```css
 section {
@@ -228,7 +124,7 @@ section.big {
 <section class="big">This has a red background and big text.</section>
 ```
 
-Chains of objects can inherit from eachother.
+Chains of classes can inherit from each other:
 
 ```css
 section.big.fancy_blue {
@@ -243,32 +139,30 @@ section.big.fancy_blue {
 </section>
 ```
 
-## Type: Mixins
+## Mixins
 
-Mixins are a way to give an object with properties directly.
-They are less formal and there is not sanctioned syntax
-in javascript.
-
-We can use `Object.assign` to give an object properties.
+Mixins give an object properties directly. They're less formal than
+classes, and JavaScript has no dedicated syntax for them — but we can use
+`Object.assign` to combine properties from several objects into one:
 
 ```javascript
 const collegeStudent = {
-  canRead:true;
-}
+  canRead: true,
+};
 const surgeon = {
-  preformSurgery(){
-    return Math.random() > 0.9 "success" : "...";
-  }
-}
+  performSurgery() {
+    return Math.random() > 0.9 ? "success" : "...";
+  },
+};
 
-const person = new Person();
+const person = {};
 Object.assign(person, surgeon, collegeStudent);
 console.log(person.canRead); // logs "true"
-console.log(person.preformSurgery()); // logs "success" (I hope)
+console.log(person.performSurgery()); // logs "success" (I hope)
 ```
 
 Notice that with mixins, an object can inherit from multiple objects
-without them having to inherit from one another.
+without any of those objects inheriting from one another.
 
 Recall the styles and markup from the previous "Extension" section:
 
@@ -294,10 +188,10 @@ section.big.fancy_blue {
 </section>
 ```
 
-We used the selectors together forming a heirchy,
-but we could have split them apart.
-This would allow them to apply to additional
-elements outside of said heirachy, in additon to the ones we defined
+We used those selectors together, forming a hierarchy — but we could just
+as easily split them apart. That would let each one apply to additional
+elements outside that hierarchy, in addition to the ones we already
+defined:
 
 ```css
 section {
@@ -319,27 +213,26 @@ section {
   This has a blue background and big italicized text.
 </section>
 <div class="big">This has big text, but no background defined.</div>
-<section class="fancy_blue">This has a blue background and italicized, but regular sized text.</div>
+<section class="fancy_blue">
+  This has a blue background and italicized, but regular sized text.
+</section>
 ```
 
-Defining CSS selectors separately
-allows properties associated
-with multiple to be mixed in
-to an HTML element.
+Defining CSS classes separately, like this, lets properties from multiple
+classes mix into a single HTML element — the same idea as `Object.assign`,
+just expressed through the cascade instead of a function call.
 
-## Prototypal
+## Prototypal Inheritance
 
-With prototypal inheritance,
-we creaete a new object referencing another object --
-a "prototype".
-We give the new object properties.
-When we attempt to access properties on the new object,
-if they do not exist; the request is proxied to the prototype.
-Objects that exist on on object's prototype, but not on the object itself,
-are considered "inherited".
+With prototypal inheritance, we create a new object that references
+another object — its "prototype" — and give the new object properties of
+its own. When we try to access a property on the new object and it
+doesn't exist there, the request is proxied to the prototype. Properties
+that exist on an object's prototype, but not on the object itself, are
+considered "inherited".
 
-In javascript, we use object `Object.create` to create an object,
-with another object as it's prototype.
+In JavaScript, we use `Object.create` to create an object with another
+object as its prototype:
 
 ```javascript
 const John = {
@@ -361,16 +254,15 @@ console.log(!!John.isEvil); // logs "false"
 console.log(!!clone.isEvil); // logs "true"
 ```
 
-When not defined by a selector targeting an element,
-some CSS properties assume a default value.
-Others take on the value of their parent.
-
-It's not completely intuitive to figure out which
-properties are inherited.
-Checkout [this stackoverflow answer](https://stackoverflow.com/a/5612360/1290781)
+This is the closest analogy to how CSS inheritance actually works. When a
+property isn't set directly on an element, some CSS properties fall back
+to a default value; others take on the value of their parent element
+instead. It's not always intuitive which properties are inherited by
+default — check out
+[this Stack Overflow answer](https://stackoverflow.com/a/5612360/1290781)
 for guidance.
 
-In this case elements inherit properties from thier parent elements.
+In this case, elements inherit properties from their parent elements:
 
 ```css
 section {
@@ -387,32 +279,39 @@ section {
 
 ## Summary
 
-Once cleard of initial styles, HTML elements can be applied
+Once you've cleared away a browser's default styles, an element's final
+appearance comes from three places, and each one maps onto a pattern of
+inheritance we just covered:
 
-    1. via style selector or directly
-    2. via
+- **A directly matching selector** — the classical pattern. A chain of
+  selectors like `section.big.fancy_blue` behaves like a chain of `extends`:
+  each link adds more specific properties on top of the last.
+- **Several independent selectors matching at once** — the mixin pattern.
+  `.big` and `.fancy_blue` don't know about each other, but both apply to
+  the same element, the same way `Object.assign` combines unrelated
+  objects.
+- **A value inherited from a parent element** — the prototypal pattern.
+  Nothing matched the element directly, so the browser walks up to the
+  parent, the same way a JavaScript object walks up its prototype chain.
 
-## Problems
+## Specificity
 
-A lot of problems stem from misunderstanings of
-css specificity and inheritence.
+Most of the confusion around CSS comes down to specificity: when more
+than one of the rules above could apply, which one wins? As a rule of
+thumb, more specific selectors (more classes, IDs, or chained selectors)
+beat more general ones, and rules that appear later in the stylesheet win
+ties.
 
-Mental tree model for inhheritne and spefificity
-Create components in increating specificity.
-Use BEM for sub components?
-From what I know about rocket science, it's honestly a bit harder
-Rocket science isn't actually that difficult onve
+A naming convention like [BEM](https://getbem.com/) can help keep
+specificity predictable as a component tree grows, since it favors flat,
+single-class selectors over long chains that are easy to lose track of.
 
-When a class extends another class,
-it's said to inherit the
-
-We'' learn more about specificity
-and how you can structure your style sheets
-to avoid shooing yousself in the foot.
+Thinking in terms of these three patterns — a direct match, a combination
+of independent classes, and inheritance from a parent — is what finally
+made CSS specificity click for me. I hope it does the same for you.
 
 ## Footnotes
 
 [^1]:
-    not "properties",
-    though we often use these interchangeably
-    when dealing whit chasses)
+    Not strictly "properties" in the CSS sense — we just use the word for
+    both, since the concepts are so similar.

--- a/src/pages/blog/posts/manage-websites-like-docker.md
+++ b/src/pages/blog/posts/manage-websites-like-docker.md
@@ -77,9 +77,9 @@ in like an image is enticing.
 
 Now that we've covered the "what" and the "why", let's look at the "how".
 
-### Prerequesites
+### Prerequisites
 
-In order complete do this tutorial, you'll need the following installed:
+In order to complete this tutorial, you'll need the following installed:
 
 #### go
 
@@ -135,7 +135,7 @@ We want a process
 that mirrors the one
 outlined above for Docker:
 
-1. Convert a file tree into an "image-like" artifact. (using `gen-bungle`)
+1. Convert a file tree into an "image-like" artifact. (using `gen-bundle`)
 2. Publish said artifact to a registry. (Github via `wasm-to-oci`)
 3. When necessary, retrieve said image from the registry and view it. (with `wasm-to-oci` and Google Chrome)
 
@@ -192,7 +192,7 @@ named "hello-world.wbn".
 This is equivalent to a Docker image.
 (Note that when you interact with docker,
 you use commands like `build`, `push`, and `pull`.
-You do not ususually interact directly
+You do not usually interact directly
 with image files themselves.)
 
 #### View Artifact
@@ -206,7 +206,7 @@ Using Chrome, visit `chrome://flags/#web-bundles`.
 Enable the feature and restart your browser.
 
 Using Chrome, open the `hello-world.wbn` file
-that you previoiusly created.
+that you previously created.
 The url will look something like
 `file:///.../hello-world.wbn?http://localhost/`.
 
@@ -237,7 +237,7 @@ to enable the distribution
 of more cloud native artifacts.
 
 There are no existing tools
-to push bundles (specificaly)
+to push bundles (specifically)
 to OCI registries.
 Fortunately, we can ~abuse~ use WASM to OCI
 -- a tool for doing something
@@ -250,13 +250,13 @@ Notably, Docker Hub does not support this.
 
 #### Login to Github with Docker
 
-We will use Docker )only\_ to authenticate
+We will use Docker _only_ to authenticate
 
 First obtain a
 [github access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 with, permissions to read and write to the registry.
 
-User `docker login` to login to the github container registry at `ghcr.io`,
+Use `docker login` to login to the github container registry at `ghcr.io`,
 
 ```bash
 echo $GITHUB_ACCESS_TOKEN | docker login ghcr.io -u $GITHUB_USERNAME --password-stdin
@@ -272,7 +272,7 @@ wasm-to-oci push ./hello-world.wbn ghcr.io/$GITHUB_USERNAME/hello-world:0.0.0
 
 If the registry at
 `https://github.com/users/$GITHUB_USERNAME/packages/container/package/hello-world`
-doest not exist, it will be created automatically.
+does not exist, it will be created automatically.
 
 You can view and manage artifacts in your repository at `https://github.com/$GITHUB_USERNAME?tab=packages`.
 
@@ -291,24 +291,16 @@ There are still a few main things missing from this work flow:
    for managing bundles
    or generic OCI images.
 
-2. The `docker run` command provides way to
-   to create a "running" container
+2. The `docker run` command provides a way to
+   create a "running" container
    by combining an image with a linux kernel.
 
    The equivalent would be
    hosting a bundle as a static asset
    such that a user can interact with it.
 
-3. The `docker run` command provides way to
-   to create a "running" container
-   by combining an image with a linux kernel.
-
-   The equivalent would be
-   hosting a bundle as a static asset
-   such that a user can interact with it.
-
-4. The `docker build` incrementally builds
-   images from other, protypal images.
+3. The `docker build` incrementally builds
+   images from other, prototypal images.
 
    The equivalent would be
    a templating system that can pull

--- a/src/pages/blog/posts/monad.md
+++ b/src/pages/blog/posts/monad.md
@@ -1,10 +1,10 @@
 # Monad
 
-## Secnario
+## Scenario
 
-Jimmy has a small blog wher he writes about nature.
+Jimmy has a small blog where he writes about nature.
 
-Each `post` in his blog is a simple stirng.
+Each `post` in his blog is a simple string.
 
 ```javascript
 post[0] = `# A dae in the life ...`;
@@ -12,9 +12,9 @@ post[2] = `# Once upon a place ...`;
 ...
 ```
 
-He has set up a some functions that allow him run with his blog.
+He has set up a few functions that allow him to work with his blog.
 
-One of these functions is `spellcheck`. It takes `post` and returns the first mispelled word. If there are no mispelled words, it returns the empty string, `""`.
+One of these functions is `spellcheck`. It takes `post` and returns the first misspelled word. If there are no misspelled words, it returns the empty string, `""`.
 
 ```javascript
 spellcheck(post[0]); // returns `"dae"`
@@ -24,10 +24,11 @@ spellcheck(post[2]); // returns `""`
 Another of these functions is `border`. It takes a `post` and puts a cool border around it.
 
 ```javascript
-border(post[0]) = `
-╔════════════  ═════════╗
- # A dae in the life ...
-╚════════════  ═════════╝`;
+border(post[0]);
+// returns `
+// ╔════════════  ═════════╗
+//  # A dae in the life ...
+// ╚════════════  ═════════╝`
 ```
 
 Jimmy has decided to take on Kate and Leo as co-authors of his blog. Unfortunately, using the current system, the strings lack author information.
@@ -41,7 +42,7 @@ type authoredPost = {
 };
 ```
 
-Now; when Jimmy, Kate, or Leo create a blog post, they can
+Now, when Jimmy, Kate, or Leo create a blog post, they can
 be sure to add an author.
 
 ```javascript
@@ -67,10 +68,10 @@ for (let i = 0; i < post.length; i++) {
 ```
 
 `Authored posts` have functionality not present in regular posts.
-Namey, the ability to have an autor added.
+Namely, the ability to have an author added.
 
 ```javascript
-const addAuthorJimmy = (post) => ({
+const addAuthorJimmy = ({ post, authors }) => ({
   post,
   authors: [...authors, "Jimmy"],
 });
@@ -85,16 +86,12 @@ Remember that Jimmy's blog has a number of functions to manage it, including `sp
 
 Jimmy worries that he'll have to re-write all of these functions. This time, Leo has an idea.
 
-Rather than individually constructing a special "authored" editon of each function (`spellcheckAuthored`, `borderAuthored`, etc.), he wants to create a single new function that takes a _transformation_ between `posts` and converts it into a transformation between `authored posts`.
-
-new function that takes an `authored post` and returns a new `authored post`.
+Rather than individually constructing a special "authored" edition of each function (`spellcheckAuthored`, `borderAuthored`, etc.), he wants to create a single new function that takes a _transformation_ between `posts` and converts it into a transformation between `authored posts`.
 
 ```javascript
-const convertAuthored = (postFunc) => {
-  (authoredPost) => {
-    const { post } = authoredPost;
-    return upgrade(postFunc(post));
-  };
+const convertAuthored = (postFunc) => (authoredPost) => {
+  const { post } = authoredPost;
+  return upgradePost(postFunc(post));
 };
 const spellcheckAuthored = convertAuthored(spellcheck);
 ```
@@ -105,26 +102,26 @@ Now, Jimmy can use `spellcheckAuthored` to check the spelling of new blogposts.
 
 The scenario above is an example of a monad.
 
-A monad is a way to give additional functioality to a group of things, while preserving functionality of the original group.
+A monad is a way to give additional functionality to a group of things, while preserving functionality of the original group.
 
 We construct a monad by:
 
 - first defining a type (call it **a**) that represents our original group of things. This was the `post` in the example above.
 
-- We then define a type (calle it **Ma**) that represents a new group,
+- We then define a type (call it **Ma**) that represents a new group,
   where these members are like those of "a", but wrapped with additional functionality. This was `authored post` in the example above.
 
-- We then define a way (call this **unit**) to transform a member of **a** into a member of **Ma**. This was the `upgrade` function in the example above.
+- We then define a way (call this **unit**) to transform a member of **a** into a member of **Ma**. This was the `upgradePost` function in the example above.
 
-- Finally, we define a way (call this **bind**) to convert any function that maps a member of **a** to **a** into a function that maps **Ma** to **Ma**. This was the `convert` function in the example above.
+- Finally, we define a way (call this **bind**) to convert any function that maps a member of **a** to **a** into a function that maps **Ma** to **Ma**. This was the `convertAuthored` function in the example above.
 
-Having defined all **a**, **Ma**, **unit**, and **bind**, we see that the secnario above formally represents a monad.
+Having defined all **a**, **Ma**, **unit**, and **bind**, we see that the scenario above formally represents a monad.
 
 ## Monad Factory
 
 We can create generic monads to better study them.
 
-We'll simplify things by chosing **a** to be the set of numbers (representable in Javascript).
+We'll simplify things by choosing **a** to be the set of numbers (representable in Javascript).
 
 As a mapping function between **a** and **a** , we choose:
 
@@ -137,10 +134,10 @@ const f = (x) => x + 1;
 
 Although **a**, **Ma** are necessary to represent a monad, they are usually implied by **unit** and **bind**.
 
-As such, all we need to define a mondad as an object is to create an object with methods represeting **unit** and **bind**.
+As such, all we need to define a monad as an object is to create an object with methods representing **unit** and **bind**.
 
-Below we creat a function that when passed a unit and a bind function,
-returns and object with them attached as methods.
+Below we create a function that, when passed a unit and a bind function,
+returns an object with them attached as methods.
 
 ```javascript
 const makeMonad = (unit, bind) => ({
@@ -162,13 +159,13 @@ const identityMonad = makeMonad(
   (x) => x,
   (x) => x
 );
-const one = monad.unit(1);
+const one = identityMonad.unit(1);
 // plusOne : a ↦ a + 1
-const plusOne = monad.bind(f);
+const plusOne = identityMonad.bind(f);
 console.log(plusOne(one)); // 2
 ```
 
-Note that no addional functionaly is provided by the identity monad.
+Note that no additional functionality is provided by the identity monad.
 
 ### List Monad
 
@@ -194,8 +191,8 @@ const ListMethods = {
     return x.filter((x) => y.includes(x));
   },
 };
-console.log(ListMethods.concat(array.unit(4), altArray.atom(5)));
-console.log(ListMethods.intersect(array.unit(4), altArray.unit(5)));
+console.log(ListMethods.concat(monad.unit(4), monad.unit(5)));
+console.log(ListMethods.intersect(monad.unit(4), monad.unit(5)));
 console.log(
   ListMethods.intersect(
     ListMethods.concat(monad.unit(4), monad.unit(5)),
@@ -235,7 +232,7 @@ const LogMethods = {
   },
   multiply(...args) {
     return {
-    value: args.reduce((p, c) => p \* c.value, 1),
+    value: args.reduce((p, c) => p * c.value, 1),
     logs: [...args.map((x) => x.logs).reverse().flat(),
       args.map((x) => x.value).join(" multiplied by "),],
     };
@@ -291,21 +288,21 @@ console.log(
 );
 ```
 
-## Inveresion
+## Inversion
 
 Monads may have a strict formal definition,
-but their usage is such that their.
+but their usage is such that there's more than one way to build one.
 
 This is similar to the previous 'makeMonad' function -- we use a similar 'unit' function, but replace the 'bind' function with a function called 'deunit' that takes a value from **Ma** and converts into a value from **a**.
 
 ```javascript
 const createMonad = (unit = (x) => x, deunit = (x) => x) => ({
-  promote,
-  deunit,
+  promote: unit,
+  demote: deunit,
 });
 ```
 
-We then create function, bindToMonad that takes our monad object, and creates **bind** from it.
+We then create a function, bindFromMonad, that takes our monad object, and creates **bind** from it.
 
 ```javascript
 const bindFromMonad = (monad) => (func) => (arg) => {
@@ -321,9 +318,9 @@ we create a slightly more complicated monad factory.
 ```javascript
 const identity = createMonad();
 const bindToIdentity = bindFromMonad(identity);
-const one = identity.unit(1);
+const one = identity.promote(1);
 const plusOne = bindToIdentity(f);
-console.log(plusOne(1)); // 2
+console.log(plusOne(one)); // 2
 ```
 
 We can modify the "bindFromMonad" function to use a function's context object (this) rather than an explicitly passed one.
@@ -344,11 +341,11 @@ This creates a function that is generically "bindable" monads created in the way
 const F = monadBindable(f);
 const identity = createMonad();
 const plusOne = F.bind(identity);
-const one = identity.unit(1);
-console.log(plusOne(1)); // 2
+const one = identity.promote(1);
+console.log(plusOne(one)); // 2
 ```
 
-This methods works for other monads as well,
+This method works for other monads as well,
 but ensure that you use a "deunit" in place of a "bind" function.
 
 ### List Monad
@@ -359,8 +356,8 @@ const list = createMonad(
   (x) => x[0]
 );
 const plusOne = F.bind(list);
-const one = list.unit(1);
-console.log(plusOne(1)); // 2
+const one = list.promote(1);
+console.log(plusOne(one)); // [2]
 ```
 
 ### Log Monad
@@ -371,8 +368,8 @@ const log = createMonad(
   (x) => x.value
 );
 const plusOne = F.bind(log);
-const one = log.unit(1);
-console.log(plusOne(1)); // {value:2, logs:[]}
+const one = log.promote(1);
+console.log(plusOne(one)); // {value:2, logs:[]}
 ```
 
 ### Maybe Monad
@@ -383,16 +380,6 @@ const maybe = createMonad(
   (x) => x.value
 );
 const plusOne = F.bind(maybe);
-const one = maybe.unit(1);
-console.log(plusOne(1)); // {value:2, null:false}
-```
-
-```javascript
-const monad = makeMonad(
-  (x) => ({ value: x, null: false }),
-  (f) => (x) => ({ value: f(x.value), null: false })
-);
-const one = monad.unit(1);
-const plusOne = monad.bind(f);
+const one = maybe.promote(1);
 console.log(plusOne(one)); // {value:2, null:false}
 ```

--- a/src/pages/blog/posts/new-site.md
+++ b/src/pages/blog/posts/new-site.md
@@ -1,6 +1,6 @@
 ---
 title: "My new website"
-description: A thorough guide to to the techniques and tools used to build my website
+description: "A thorough guide to the techniques and tools used to build my website"
 author: "John Henry"
 heroImage: "/vendor/img/www.pexels.com/pixabay/view-of-street-from-a-glass-window.jpg"
 alt: "Astro"
@@ -10,13 +10,13 @@ tags: ["experimenting", "programming"]
 
 _Author’s Note: This is a **Highly Opinionated** guide. Your experiences and preferences may differ._
 
-## Introduction and Openess
+## Introduction and Openness
 
 I've learned most of what I have
 by looking at what others have built before me.
 The ability to select "view source"
 from the browser's context menu
-has been key to what I've been able to learn.
+has been key to what I've been able to learn
 as a developer.
 Being able to use and examine
 source code in public repositories
@@ -40,7 +40,7 @@ As such, they may not be suitable for production;
 but using modern tooling,
 you can get around this.
 They are also available in their
-[own github repository](http://github.johnhenry.io/lib)
+[own github repository](https://github.com/johnhenry/lib)
 where I am currently working
 on documentation detailing
 how you too can use these modules
@@ -56,38 +56,30 @@ we use a static compiler in place of markup.
 For this site, I use [Astro](https://astro.build)
 as a framework to compose and compile HTML components
 written as "./astro" files.
-I don't publish these directly at http://johnhenry.io/lib/
+I don't publish these directly at https://johnhenry.github.io/lib/
 as you can't simply pull them into an application
 in the same way you do javascript files;
 but they are available on
-[this site's github repository](https://github.com/johnhenry.github.io)
+[this site's github repository](https://github.com/johnhenry/johnhenry.github.io)
 and I may publish them elsewhere in the future.
 
 HTML Tags are semantic components.
-Classes represent variations
-
-# reset
+Classes represent variations on that theme.
 
 ## Exceptions
 
 For the most part, I try to keep the style separate from the markup.
-That said, there are a few exceptions where I use the HTML structure
+That said, there are a few exceptions where I let the HTML structure itself carry some of the styling.
 
 For example, for the buttons in the .widget components,
 I've wrapped each letter in a span then styled those as a flex-box for the desired effect.
-
-## Unansered Questions
 
 ## Future
 
 Astro 21 -- embed components into blog posts
 
-/\*
+Some open style guidelines I'm still weighing:
 
-- style a component primarily by **tag** if it is reusable throughtout
-  the application
-- add a **class** for slight variations
-  _/
-  /_
+- style a component primarily by **tag** if it is reusable throughout
+  the application; add a **class** for slight variations
 - style components primarily by **class** if its semantic interpretation goes beyond the set of built-in HTML tags
-  \*/

--- a/src/pages/blog/posts/semantics-vs-accessibility.md
+++ b/src/pages/blog/posts/semantics-vs-accessibility.md
@@ -55,7 +55,7 @@ create components that are unaware of their containers.
 
 Semantically, a top level heading within a component shouldn't depend upon the headings of its ancestors.
 
-You would be tempted do this:
+You would be tempted to do this:
 
 ```html
 <body>
@@ -87,7 +87,7 @@ Sadly, it was [never implemented](https://adrianroselli.com/2016/08/there-is-no-
 But, in the case of HTML headings; if a section has a heading of "h2",
 it must be the child of a section with an "h1".
 A section with an "h3"
-must have a parent with and "h2" and so on.
+must have a parent with an "h2" and so on.
 
 The problem arises in that _using sensical **semantics** to create components is at odds with how screenreaders interpret **accessibility** cues in HTML_... or...
 
@@ -108,8 +108,8 @@ to other environments.
 ```astro
 ---
 // file:///./boring-section.astro
-const parentLevel = Astro.props.paerentLevel || 0;
-const currentLevel = Astro.props.currentLevel = parentLevel + 1;
+const parentLevel = Astro.props.parentLevel || 0;
+const currentLevel = parentLevel + 1;
 ---
 <style>
 section {
@@ -126,8 +126,8 @@ section {
 ```astro
 ---
 // file:///./fancy-section.astro
-const parentLevel = Astro.props.paerentLevel || 0;
-const currentLevel = Astro.props.currentLevel = parentLevel + 1;
+const parentLevel = Astro.props.parentLevel || 0;
+const currentLevel = parentLevel + 1;
 ---
 <style>
   section {
@@ -145,7 +145,6 @@ const currentLevel = Astro.props.currentLevel = parentLevel + 1;
 ---
 import BoringSection from "./boring-section.astro";
 import FancySection from "./fancy-section.astro";
----
 ---
 <body>
   <BoringSection>
@@ -171,7 +170,7 @@ This will produce the following HTML:
 ```
 
 You can use a utility function
-to make the code a bit cleaner a bit cleaner.
+to make the code a bit cleaner.
 
 ```javascript
 // file:///./get-level.mjs
@@ -202,7 +201,7 @@ to manually pass the parentLevel property
 through to each child.
 
 Using nested, indexed for loops may help,
-but I can already imagine being convoluted.
+but I can already imagine it being convoluted.
 
 The [React Context API](https://reactjs.org/docs/context.html) and the
 [Vue Provide/Inject API](https://v3.vuejs.org/guide/component-provide-inject.htm)

--- a/src/pages/blog/posts/vscode-on-remote-server.md
+++ b/src/pages/blog/posts/vscode-on-remote-server.md
@@ -21,9 +21,9 @@ It is not difficult to do this using secure shell alone, but here are a few meth
 
 ## Pre-Requisites
 
-This tutorial assumes that you are already famaliar with using [secure shell (SSH)](https://en.wikipedia.org/wiki/Secure_Shell).
+This tutorial assumes that you are already familiar with using [secure shell (SSH)](https://en.wikipedia.org/wiki/Secure_Shell).
 
-You _should_ at least be famaliar with logging into a remote server using [key-based authentication](https://www.ssh.com/ssh/key/).
+You _should_ at least be familiar with logging into a remote server using [key-based authentication](https://www.ssh.com/ssh/key/).
 
 ## Method 1 : code-server
 
@@ -36,7 +36,7 @@ You _should_ at least be famaliar with logging into a remote server using [key-b
 
 ## Method 2 : sshcode
 
-[Sshcode](https://github.com/cdr/sshcode) works similarly to code-server (it's actually built on top of it) but uses a client program to set up the web server. Additionally, if you're using chrome, it will open a customized window with Visual Studio Code keybinding in tact.
+[Sshcode](https://github.com/cdr/sshcode) works similarly to code-server (it's actually built on top of it) but uses a client program to set up the web server. Additionally, if you're using chrome, it will open a customized window with Visual Studio Code keybinding intact.
 
 0. Install chrome and sshcode on client
 1. On client, run `sshcode <user>@<serveraddress>`
@@ -55,6 +55,6 @@ You _should_ at least be famaliar with logging into a remote server using [key-b
 To supplement the above methods, you may want to learn about:
 
 - mounting file remote folders locally and using any editor you want using [sshfs](https://github.com/libfuse/sshfs)
-- accessing other resources on your remote maching via [tunneling](https://www.ssh.com/ssh/tunneling/example).
+- accessing other resources on your remote machine via [tunneling](https://www.ssh.com/ssh/tunneling/example).
 - mitigating unstable remote [mobile] connections with [mosh](https://mosh.org/).
-- customizations and pitfalls of above programs by reading their documetion.
+- customizations and pitfalls of above programs by reading their documentation.


### PR DESCRIPTION
## Summary
Deep-dive audit of CSS consistency, component structure, and blog post quality, followed by fixes for everything confirmed as a real bug (not just style preference).

## Real bugs fixed
- **CSS**: `--color-text-highlight` vs `--color-text--highlight` (and 2 more with the same typo) — hover/active states on header/footer links and inverted links did nothing, live in production, until this fix.
- **GDPR banner**: used Tailwind-style classes (`fixed`, `bottom-0`, `flex`, etc.) that don't exist anywhere in this site's CSS or its lib dependency — the cookie consent banner had zero real layout styling. Added `gdpr-request.css`, verified visually.
- **Dead prop**: `headerLinks` was forwarded through `BlogPage` → `SitePage` → `GenericPage`, none of which read it — `SiteBody.astro` already imports it directly.
- **monad.md**: every code example now actually executes (I ran them all in Node to confirm) — found a function that never returned its closure, an undefined-variable reference, a nonexistent `.unit()` method being called, and 5 examples calling their result function with the wrong argument.
- **semantics-vs-accessibility.md**: the Astro example read `Astro.props.paerentLevel` (typo) while the demo passed the correctly-spelled `parentLevel` — the example never worked as written.
- **manage-websites-like-docker.md**: an entire paragraph was verbatim duplicated.
- **angular-done-right.md / browsers-servers-and-apis.md**: every code-block quote was corrupted from the original Medium copy-paste (curly quotes), making every example non-copy-pasteable; one `ng-repeat` example was mangled across a dozen broken lines. Fixed code blocks only — prose left untouched.

## Also
- `component.md` — full rewrite as requested (was two unfinished drafts stapled together, no frontmatter, never published). Now a complete, dated, listed post: "CSS Inheritance for JavaScript Programmers".
- `new-site.md` — completed dangling sentences, fixed 3 broken URLs, cleaned up a markdown-mangled comment block.
- Typo passes on `vscode-on-remote-server.md` and the two Medium-import posts' prose.
- Cosmetic: merged duplicate CSS rules, deduped a double-fetched reset.css URL, standardized import quote style.

## Verification
Full site build after every change; monad.md and semantics-vs-accessibility.md's corrected code was executed directly in Node (not just visually inspected) to confirm it actually runs. GDPR banner fix verified with a live screenshot + computed-style check via chrome-devtools.