### PR TITLE
Fix "Invalid date" in Outstatic for migrated posts

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -34,11 +34,19 @@ const projects = defineCollection({
   }),
 });
 
-// New CMS-authored posts land here going forward; the 11 existing posts stay
-// as plain pages in src/pages/blog/posts/ (see src/utils/get-all-posts.mjs).
+// All blog posts live here, editable via Outstatic (see get-all-posts.mjs,
+// which also merges in any future file-based pages if ever added again).
 const posts = defineCollection({
   loader: glob({ pattern: "**/*.md", base: "./src/content/posts" }),
   schema: z.object({
+    // Outstatic's own document editor/list UI requires these two on every
+    // document in every collection, independent of our own schema -- without
+    // them the CMS dashboard shows "Invalid date" and editing fails
+    // validation. Not used by this site's own rendering (which keys off
+    // `date` below for sort/display/RSS-inclusion), only by Outstatic itself.
+    publishedAt: z.coerce.date(),
+    status: z.enum(["published", "draft"]).default("published"),
+
     title: z.string(),
     description: z.string().optional(),
     // Free-text to match legacy posts' non-ISO dates ("1 August 2013"); new

--- a/src/content/posts/angular-done-right.md
+++ b/src/content/posts/angular-done-right.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2013-08-01T07:00:00.000Z"
+status: "published"
 title: "Angular Done Right: Part 1"
 description: "The first in a series on how to use Angular 1.0"
 date: "1 August 2013"

--- a/src/content/posts/browsers-servers-and-apis.md
+++ b/src/content/posts/browsers-servers-and-apis.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2019-05-01T07:00:00.000Z"
+status: "published"
 title: "Browsers, Servers, and APIs"
 description: "Using servers in the browsers"
 date: "1 May 2019"

--- a/src/content/posts/cascading-document-type-definitions.md
+++ b/src/content/posts/cascading-document-type-definitions.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2022-06-18T07:00:00.000Z"
+status: "published"
 title: "Cascading Document Type Definitions"
 description: "An introduction to CDTDs"
 date: "18 June 2022"

--- a/src/content/posts/component.md
+++ b/src/content/posts/component.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2026-07-03T07:00:00.000Z"
+status: "published"
 title: "CSS Inheritance for JavaScript Programmers"
 description: "Classical inheritance, mixins, and prototypal inheritance in JavaScript, and what each one teaches us about how CSS inheritance and specificity actually work."
 date: "3 July 2026"

--- a/src/content/posts/html-tags-for-data.md
+++ b/src/content/posts/html-tags-for-data.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2021-11-10T02:31:50.000Z"
+status: "published"
 title: "HTML Tags for Data"
 description: "The first in a series on how to use Angular 1.0"
 author: "John Henry"

--- a/src/content/posts/manage-websites-like-docker.md
+++ b/src/content/posts/manage-websites-like-docker.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2021-10-26T07:00:00.000Z"
+status: "published"
 title: "Manage Websites Like Docker"
 description: Manage static websites like you manage Docker images
 author: "John Henry"

--- a/src/content/posts/monad.md
+++ b/src/content/posts/monad.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2022-07-28T05:14:49.000Z"
+status: "published"
 title: "Monad"
 description: "A playful introduction to monads through a small thought experiment about a blog"
 author: "John Henry"

--- a/src/content/posts/native-dom-nodes.md
+++ b/src/content/posts/native-dom-nodes.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2022-06-26T05:21:15.000Z"
+status: "published"
 title: "Native DOM Nodes"
 description: A novel approach to using traditional methods in web develoment
 author: "John Henry"

--- a/src/content/posts/new-site.md
+++ b/src/content/posts/new-site.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2021-10-23T23:17:43.000Z"
+status: "published"
 title: "My new website"
 description: "A thorough guide to the techniques and tools used to build my website"
 author: "John Henry"

--- a/src/content/posts/semantics-vs-accessibility.md
+++ b/src/content/posts/semantics-vs-accessibility.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2021-11-04T07:00:00.000Z"
+status: "published"
 title: "Semantics Versus Accessibility"
 description: "We explore an issue plaguing modern development and propose a solution"
 date: "4 November 2021"

--- a/src/content/posts/vscode-on-remote-server.md
+++ b/src/content/posts/vscode-on-remote-server.md
@@ -1,4 +1,6 @@
 ---
+publishedAt: "2019-09-07T07:00:00.000Z"
+status: "published"
 title: "VS Code on a Remote Server"
 description: "How to run Visual Studio Code on a remote server"
 date: "7 September 2019"


### PR DESCRIPTION
## Summary
Outstatic's own document editor/list UI requires `publishedAt` (a real date) and `status` on every document in every collection, independent of this repo's own Zod schema. Confirmed in `outstatic`'s client bundle: it does `new Date(doc.publishedAt).toLocaleDateString(...)` for each document's date badge, and its edit form validates `publishedAt` as a required date field. None of the 11 migrated posts had this field (the `posts` schema was modeled only on the old blog frontmatter shape), so every post showed "Invalid date" in the CMS dashboard.

- 7 posts with an existing `date` string get `publishedAt` as that same date in ISO form.
- 4 posts with no `date` (`monad`, `new-site`, `html-tags-for-data`, `native-dom-nodes`) get `publishedAt` from their original first-commit date in git history.
- `status: "published"` added to all 11, matching the convention the `projects` collection already follows.

This only affects the Outstatic dashboard -- the site's own rendering still keys off `date`/`sort-posts.mjs` exactly as before.

## Test plan
- [x] `npm run build` succeeds, zero Zod errors
- [x] Same 11 post URLs, byte-identical
- [x] Same 7 RSS items/links
- [x] Same dates shown on `/blog` listing