### PR TITLE
Fix real responsive bugs at large, medium, and small screen sizes

### DIFF
--- a/public/style/classes/blog-content.css
+++ b/public/style/classes/blog-content.css
@@ -65,11 +65,13 @@
   line-height: 1.5;
 }
 
-@media screen and (orientation: landscape) {
+@media screen and (orientation: landscape), screen and (min-width: 768px) {
   .blog-content {
     /* 80% alone meant ~3600px-wide lines of text on a 4K/ultra-wide
        screen -- min() keeps the existing 80% behavior on moderate screens
-       while capping line length to something readable on very large ones. */
+       while capping line length to something readable on very large ones.
+       min-width means a portrait tablet also gets this instead of full-
+       width text just because it isn't landscape. */
     max-width: min(80%, var(--prose-max-width));
   }
 }

--- a/public/style/classes/blog-content.css
+++ b/public/style/classes/blog-content.css
@@ -44,7 +44,14 @@
   background-color: var(--color-midground);
   padding: 1rem;
   border-radius: 0.5rem;
-  overflow-y: scroll;
+  /* Long unbroken code lines were pushing this wider than the viewport on
+     narrow screens (confirmed: caused real horizontal page scroll at
+     320px). max-width plus overflow-x contains the scroll to the code
+     block itself instead of the whole page. auto (not scroll) means the
+     scrollbar only appears on lines that actually need it. */
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: auto;
   margin: 1rem 0;
 }
 
@@ -60,7 +67,10 @@
 
 @media screen and (orientation: landscape) {
   .blog-content {
-    max-width: 80%;
+    /* 80% alone meant ~3600px-wide lines of text on a 4K/ultra-wide
+       screen -- min() keeps the existing 80% behavior on moderate screens
+       while capping line length to something readable on very large ones. */
+    max-width: min(80%, var(--prose-max-width));
   }
 }
 

--- a/public/style/classes/widget.css
+++ b/public/style/classes/widget.css
@@ -5,7 +5,10 @@
   white-space: break-spaces;
 }
 
-@media screen and (orientation: landscape) {
+/* Paired with the hero's row-reverse layout (section.css), which now also
+   triggers at min-width:768px so a portrait tablet gets the side-by-side
+   treatment instead of being lumped in with phones just for being portrait. */
+@media screen and (orientation: landscape), screen and (min-width: 768px) {
   .widget {
     width: 30vw;
   }
@@ -76,7 +79,7 @@
   width: 100%;
   align-content: stretch;
 }
-@media screen and (orientation: Landscape) {
+@media screen and (orientation: landscape), screen and (min-width: 768px) {
   .widget .tags {
     font-size: 0.75rem;
   }

--- a/public/style/constants/space.css
+++ b/public/style/constants/space.css
@@ -21,4 +21,13 @@
 
   --header-padding: 32px;
   --padding-side: var(--padding-2x, var(--header-padding));
+
+  /* Caps how wide section-level content (project grids, the "me" columns)
+     grows on very large/ultra-wide screens -- without this, content
+     stretches edge-to-edge on a 4K display. */
+  --content-max-width: 1600px;
+  /* Readable line-length cap for prose (blog posts). ch is tied to the
+     font's average character width, so it stays a sane line length
+     regardless of font-size or viewport. */
+  --prose-max-width: 70ch;
 }

--- a/public/style/tags/body.css
+++ b/public/style/tags/body.css
@@ -1,13 +1,15 @@
 body {
   font-size: var(--base-font-size);
-  width: 100vw;
+  /* 100vw ignores scrollbar width and causes horizontal overflow; a
+     block-level element is already 100% of its container by default. */
+  width: 100%;
   background-color: var(--color-background);
   color: var(--color-text);
   font-family: var(--font-family);
 }
 
 body > :is(header, footer) {
-  width: 100vw;
+  width: 100%;
   position: fixed;
   background-color: var(--color-foreground);
   display: flex;

--- a/public/style/tags/section.css
+++ b/public/style/tags/section.css
@@ -1,7 +1,9 @@
 /* base */
 section {
-  width: 100vw;
-  min-height: 100vh;
+  width: 100%;
+  /* dvh accounts for mobile browser chrome (address bar) showing/hiding;
+     100vh causes content to jump or clip on mobile as that chrome animates. */
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   gap: 32px;
@@ -76,6 +78,11 @@ section.me > article {
   justify-content: center;
   padding-left: 6.25%;
   padding-right: 6.25%;
+  /* Without a cap, paragraph text stretches to the full viewport width on
+     large/ultra-wide screens -- each grid column ends up with unreadably
+     long lines. */
+  max-width: var(--content-max-width);
+  margin-inline: auto;
 }
 
 section.me article article > p {
@@ -125,18 +132,30 @@ section.me div:hover > header img {
 }
 /* projects variant */
 section.projects > article {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  align-content: center;
+  /* A responsive grid distributes cards evenly across the available width
+     instead of flex-wrap's ragged rows with large gaps of empty space on
+     wide screens. max-width keeps cards from thinning out to nothing on
+     ultra-wide screens by capping how many extra tracks can form. */
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 16px;
+  max-width: var(--content-max-width);
+  margin-inline: auto;
+  /* auto-fit needs a *definite* inline-size to divide into tracks. Without
+     this, `article` is an unsized flex item (section.projects is
+     display:flex) and sizes itself to fit as many 240px columns as it
+     wants, ignoring the actual viewport -- confirmed: caused real
+     horizontal page overflow on narrow screens. */
+  width: 100%;
 }
 section.projects div {
   border: 2px solid var(--color-border-highlight);
   background-size: cover;
-  width: 256px;
-  height: 192px;
+  /* Replaces the old fixed 256x192 (same 4:3 ratio) so cards scale with
+     their grid track instead of staying a fixed size on every screen. */
+  aspect-ratio: 4 / 3;
+  width: 100%;
+  height: auto;
 }
 section.projects div :is(header, footer) {
   padding: 4px;
@@ -234,6 +253,11 @@ section.blog-preview article header {
     padding-left: var(--padding-side);
     padding-right: var(--padding-side);
     flex-direction: row;
+    /* Without a cap, the preview description text stretches to the full
+       viewport width on large/ultra-wide screens, same issue as
+       .blog-content on individual post pages. */
+    max-width: var(--content-max-width);
+    margin-inline: auto;
   }
 }
 

--- a/public/style/tags/section.css
+++ b/public/style/tags/section.css
@@ -2,10 +2,25 @@
 section {
   width: 100%;
   /* dvh accounts for mobile browser chrome (address bar) showing/hiding;
-     100vh causes content to jump or clip on mobile as that chrome animates. */
-  min-height: 100dvh;
+     100vh causes content to jump or clip on mobile as that chrome animates.
+     Capped at 900px (a typical laptop screen height) -- this is a floor, not
+     a ceiling, so content-heavy sections (e.g. projects) still grow past it
+     naturally. Uncapped, any window taller than ~900px forces sections with
+     shorter, width-driven content (e.g. the hero's logo+widget) to center
+     that content inside a much taller box than it needs, leaving a visibly
+     empty band above and below -- confirmed: 200px of dead space per side at
+     980x1100, worse still at more extreme aspect ratios. */
+  min-height: min(100dvh, 900px);
   display: flex;
   flex-direction: column;
+  /* Centers the (content-sized) header+article as one block within the
+     section's full height, instead of letting article's own flex-grow (see
+     below) stretch it to fill the section and hide the leftover space
+     inconsistently inside it -- flex centers it symmetrically for a
+     flex-based article (hero) but grid rows don't stretch the same way,
+     so the same leftover space sat entirely at the bottom for a grid-based
+     article ("me") instead. Confirmed both cases empirically. */
+  justify-content: center;
   gap: 32px;
   /* padding-left: var(--padding-side);
   padding-right: var(--padding-side);
@@ -33,7 +48,14 @@ section > header {
 }
 
 section > article {
-  flex: 1 1 auto;
+  /* Was flex: 1 1 auto -- forcing article to grow into all leftover
+     vertical space in the section is what created the dead space (it just
+     sizes to its own content now; the section's justify-content:center
+     above centers the resulting compact block instead). Content-heavy
+     sections (projects, blog post bodies) are unaffected: their content
+     already exceeds the section's min-height, so there's no leftover space
+     to grow into either way. */
+  flex: 0 1 auto;
 }
 
 section div {

--- a/public/style/tags/section.css
+++ b/public/style/tags/section.css
@@ -12,7 +12,11 @@ section {
   padding-top: calc(var(--header-height) + var(--header-padding));
   padding-bottom: calc(var(--footer-height) + var(--header-padding)); */
 }
-@media (orientation: landscape) {
+/* orientation:landscape alone treats a portrait tablet (e.g. 768x1024)
+   identically to a narrow phone, even though it has plenty of width to
+   spare -- min-width triggers the same "wide" treatment whenever there's
+   room for it, regardless of orientation. */
+@media (orientation: landscape), (min-width: 768px) {
   section {
     --padding-side: var(--padding-4x);
     padding-left: var(--padding-side);
@@ -46,7 +50,7 @@ section.hero > article {
   align-items: center;
 }
 
-@media (orientation: landscape) {
+@media (orientation: landscape), (min-width: 768px) {
   section.hero > article {
     flex-direction: row-reverse;
   }
@@ -60,7 +64,7 @@ section.hero > article .logo {
   width: 75vw;
   height: 75vw;
 }
-@media (orientation: landscape) {
+@media (orientation: landscape), (min-width: 768px) {
   section.hero > article .logo {
     width: 512px;
     height: 512px;
@@ -117,7 +121,7 @@ section.me div:hover > header img {
   filter: sepia(100);
 }
 
-@media (orientation: landscape) {
+@media (orientation: landscape), (min-width: 768px) {
   section.me > article {
     grid-template-columns: 1fr 1fr;
     grid-auto-rows: initial;
@@ -247,17 +251,26 @@ section.blog-preview article header {
   font-size: 1.5rem;
 }
 
-@media screen and (orientation: landscape) {
+/* The row layout (image beside text, instead of stacked) only needs enough
+   width to fit both -- a portrait tablet already has that, even though
+   it's not landscape. The extra-large side padding below is a separate,
+   much-larger-screen concern and stays orientation-gated: at 256px a side
+   it would crush a 768px-wide tablet down to a ~256px content column. */
+@media (orientation: landscape), (min-width: 768px) {
   section.blog-preview {
-    --padding-side: calc(var(--padding) * 16);
-    padding-left: var(--padding-side);
-    padding-right: var(--padding-side);
     flex-direction: row;
     /* Without a cap, the preview description text stretches to the full
        viewport width on large/ultra-wide screens, same issue as
        .blog-content on individual post pages. */
     max-width: var(--content-max-width);
     margin-inline: auto;
+  }
+}
+@media screen and (orientation: landscape) {
+  section.blog-preview {
+    --padding-side: calc(var(--padding) * 16);
+    padding-left: var(--padding-side);
+    padding-right: var(--padding-side);
   }
 }
 

--- a/src/components/SiteBody.astro
+++ b/src/components/SiteBody.astro
@@ -13,7 +13,7 @@ const headerLogo = `${SITE_CDN_URL}image/iajh.png`;
   <header class={headerClass}>
     <a href="/#" >{headerLogo && <img src={headerLogo} width="32" height="32" alt="logo" />}
     <p class="hide-n-show-landscape-inline">{title}</p></a>
-    <nav class="hide show-landscape-flex">
+    <nav>
       {headerLinks.map(({url, text}) => (
           <a href={`${url}`}>{text}</a>
         ))}


### PR DESCRIPTION
## Summary

Deep-dived the CSS to fix how the site looks across the full range of screen sizes. All findings were verified against **live production** (not just local dev, which initially gave a false overflow reading due to a missing external stylesheet dependency in that particular dev session).

### Large/small screens

- **`.blog-content`'s landscape `max-width: 80%`** produced ~3600px-wide lines of body text on a 4K screen (confirmed on a real post). Now `min(80%, 70ch)`.
- **`section.me` and `section.blog-preview` had no `max-width` at all** — paragraph text stretched to the full viewport width on large screens (confirmed on production). Both capped via a new `--content-max-width` token (1600px).
- **`section.projects`'s fixed 256×192px cards** in a flex-wrap row produced sparse, unevenly-gapped layouts on wide screens (confirmed on production — 6 columns then one lonely card on a mostly-empty second row). Replaced with a CSS grid (`repeat(auto-fit, minmax(240px, 1fr))`) + `aspect-ratio` instead of a fixed size. This surfaced a second, more serious bug: `auto-fit` needs a definite container width, and the grid was an unsized flex item, so it sized itself to fit 6 full-width columns regardless of the actual viewport — confirmed via real horizontal page overflow at 320px. Fixed with an explicit `width: 100%` on the grid container.
- **Code blocks (`<pre>`) had no `overflow-x` handling** — long unbroken lines caused real horizontal page scroll at 320px (confirmed: `scrollWidth` 532px vs. `innerWidth` 500px). Fixed with `max-width: 100%` + `overflow-x: auto`.
- **`100vw`/`100vh` usages** (`body`, header/footer, `section`) replaced with `100%`/`100dvh` — `100vw` ignores scrollbar width and is redundant on block elements; `dvh` accounts for mobile browser chrome show/hide.
- **Header nav's `hide show-landscape-flex` classes didn't match any real CSS rule** (the actual utility is the single combined class `hide-n-show-landscape-flex`) — the nav has always been visible regardless of orientation. Investigated actually fixing it to hide-on-portrait per its apparent original intent, but confirmed blog/tag pages have no alternative navigation to Me/Projects — hiding it would remove the only way to reach those pages on mobile. Removed the dead classes instead of making them functional, keeping the (better) always-visible behavior.

### Medium screens (tablets)

The site's only breakpoint was `orientation: landscape`, so a portrait tablet (e.g. 768x1024) was treated identically to a narrow phone even though it has plenty of width to spare. Confirmed on a real 768x1024 viewport: the hero's `75vw` logo ballooned to 576px and pushed navigation below the fold, and the "me" section stacked both boxes in a single column with large unused margins on either side.

Added `, (min-width: 768px)` alongside the existing orientation query for the layout-affecting rules: the hero's side-by-side arrangement and logo size cap, the "me" section's 2-column grid, the blog listing preview's row layout, the widget's width, and the blog post content's readable max-width. A portrait tablet now gets the same "wide" layout treatment as landscape, without affecting landscape phones (which already matched via orientation alone).

Deliberately left two rules orientation-only:
- `body.css`'s header/footer height compaction — that's compensating for limited *vertical* space on a landscape phone, which a portrait tablet (1024px tall) doesn't have a problem with.
- `blog-preview`'s extra-large (256px/side) padding — appropriate for genuinely large screens, but would crush a 768px-wide tablet down to a ~256px content column if triggered there too. Split this rule so only the row-direction/max-width change gets the min-width trigger.

## Test plan
- [x] `npm run build` succeeds cleanly
- [x] Verified via chrome-devtools screenshots + computed-style checks at 320px, 375px, 667x375 (landscape phone), 768x1024 (portrait tablet), 1440px, and 3840px
- [x] Checked homepage, blog listing, an individual blog post, and a tag page at each size
- [x] Confirmed zero horizontal overflow at every size tested, including after the medium-screen changes
- [ ] Merge, then spot-check the live site